### PR TITLE
Updated README for Linux installation & Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,35 +13,21 @@
 ## Installation
 
 ### Windows
-[Download MR 2.2.7 64Bit Windows](https://revskills.de/MR_64Bit_Windows.exe)
+
+Download MR 2.2.7 64Bit Windows
+
 - Just install. Scripts will be added to "User Documents/MobileRevelator"
-- Please note that when analyzing mobile filesystems, Windows will not support dangling symbolic links, which could lead to many files being assigned 0 bytes. 
 
 ### Linux
 
-These are the instructions for how to install MR on a Debian distribution of Linux. For other distributions, you can follow [CyberCiti's instructions to view packages.](https://www.cyberciti.biz/faq/show-display-get-installed-packages-software-list-linux-freebsd-openbsd/)
+Download MR 2.2.7 64Bit Linux
 
-This program requires libssl 1.0.0 and OpenSSL 1.0.2. It will not run with updated versions of those packages, so below are instructions for how to install them on your system.
+- Templates and Plugins are in the "~/Documents/MobileRevelator" folder
+- Use the chmod command to enable execution. 
+  - "chmod +x Mobile_Revelator-x86_64.AppImage"
+- Run the AppImage. "./Mobile_Revelator-x86_64.AppImage"
+- If the app crashes, "export QT_NO_FT_CACHE=1" first.
 
-1. `wget https://revskills.de/MR_x86_64_Linux.zip`
-2. `unzip MR_x86_64_Linux.zip`
-3. Check libssl version with `dpkg --get-selections | grep libssl`
-4. If libssl version is 1.0.0 skip to step 11. Otherwise continue.
-5. `cd etc/apt`
-6. `nano sources.list`
-7. Add `deb http://security.debian.org/debian-security jessie/updates main`
-8. Save and Exit. 
-9. Restart your system.
-10. `sudo apt install libssl1.0.0`
-11. Check openssl version with `openssl version`
-12. If version is 1.0.2, skip to step 14. Otherwise continue.
-13. [Follow this guide to install OpenSSL 1.0.2](https://www.howtoforge.com/tutorial/how-to-install-openssl-from-source-on-linux/)
-14. `./MR_x86_64_Linux.appimage`
-
-- Template/Plugins are stored in "~/Documents/MobileRevelator"
-- If the AppImage is not executable by default, use `chmod +x MR_x86_64_Linux.appimage` to make it executable.
-- If the app crashes, run `export QT_NO_FT_CACHE=1` first.
-- The latest version of Kali Linux will not support package installations over http, so the above solution will not work. 
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,29 @@
 - Just install. Scripts will be added to "User Documents/MobileRevelator"
 
 ### Linux
-[Download MR 2.2.7 64Bit Linux](https://revskills.de/MR_x86_64_Linux.zip)
-- Templates and Plugins are in the "~/Documents/MobileRevelator" folder
-- "chmod +x MR_x86_64_Linux.appimage"
-- "MR_x86_64_Linux.appimage"
-- If the app crashes, "export QT_NO_FT_CACHE=1" first.
+
+These are the instructions for how to install MR on a Debian distribution of Linux. For other distributions, you can follow [CyberCiti's instructions to view packages.](https://www.cyberciti.biz/faq/show-display-get-installed-packages-software-list-linux-freebsd-openbsd/)
+
+This program requires libssl 1.0.0 and OpenSSL 1.0.2. It will not run with updated versions of those packages, so below are instructions for how to install them on your system.
+
+1. `wget https://revskills.de/MR_x86_64_Linux.zip`
+2. `unzip MR_x86_64_Linux.zip`
+3. Check libssl version with `dpkg --get-selections | grep libssl`
+4. If libssl version is 1.0.0 skip to step 11. Otherwise continue.
+5. `cd etc/apt`
+6. `nano sources.list`
+7. Add `deb http://security.debian.org/debian-security jessie/updates main`
+8. Save and Exit. 
+9. Restart your system.
+10. `sudo apt install libssl1.0.0`
+11. Check openssl version with `openssl version`
+12. If version is 1.0.2, skip to step 14. Otherwise continue.
+13. [Follow this guide to install OpenSSL 1.0.2](https://www.howtoforge.com/tutorial/how-to-install-openssl-from-source-on-linux/)
+14. `./MR_x86_64_Linux.appimage`
+
+- Template/Plugins are stored in "~/Documents/MobileRevelator"
+- If the AppImage is not executable by default, use `chmod +x MR_x86_64_Linux.appimage` to make it executable.
+- If the app crashes, run `export QT_NO_FT_CACHE=1` first.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ### Windows
 [Download MR 2.2.7 64Bit Windows](https://revskills.de/MR_64Bit_Windows.exe)
 - Just install. Scripts will be added to "User Documents/MobileRevelator"
+- Please note that when analyzing mobile filesystems, Windows will not support dangling symbolic links, which could lead to many files being assigned 0 bytes. 
 
 ### Linux
 
@@ -40,6 +41,7 @@ This program requires libssl 1.0.0 and OpenSSL 1.0.2. It will not run with updat
 - Template/Plugins are stored in "~/Documents/MobileRevelator"
 - If the AppImage is not executable by default, use `chmod +x MR_x86_64_Linux.appimage` to make it executable.
 - If the app crashes, run `export QT_NO_FT_CACHE=1` first.
+- The latest version of Kali Linux will not support package installations over http, so the above solution will not work. 
 
 ## Examples
 


### PR DESCRIPTION
README.md now has detailed steps for installing MR's dependencies (on a Debian system) and an added note about an issue when performing analysis on Windows. 

The fix already has one quirk since the latest Kali Linux update will no longer accept packages over http, but I do not know if other Linux distributions have the same protections in place. 